### PR TITLE
prefer-alias-import works with import equals syntax

### DIFF
--- a/dist/rules/prefer-alias-imports.js
+++ b/dist/rules/prefer-alias-imports.js
@@ -122,6 +122,17 @@ exports.default = (0, createRule_1.createRule)({
         const currentAlias = getMatchingAlias(paths, currentRelativeFilename);
         const validatePath = buildPathValidator(context, options, paths, absoluteBaseUrl, currentPath, currentAlias);
         return {
+            TSImportEqualsDeclaration(node) {
+                if (node.moduleReference.type == 'TSExternalModuleReference') {
+                    const literal = node.moduleReference.expression;
+                    if (literal && literal.type === 'Literal') {
+                        const source = literal.value;
+                        if (typeof source === 'string') {
+                            validatePath(literal, source);
+                        }
+                    }
+                }
+            },
             CallExpression(node) {
                 var _a;
                 if (isRequireStatement(node.callee) || isJestMock(node.callee)) {

--- a/src/rules/prefer-alias-imports.ts
+++ b/src/rules/prefer-alias-imports.ts
@@ -147,6 +147,17 @@ export default createRule<[Options], MessageIds>({
       currentAlias,
     );
     return {
+      TSImportEqualsDeclaration(node) {
+        if (node.moduleReference.type == 'TSExternalModuleReference') {
+          const literal = node.moduleReference.expression;
+          if (literal && literal.type === 'Literal') {
+            const source = literal.value;
+            if (typeof source === 'string') {
+              validatePath(literal, source);
+            }
+          }
+        }
+      },
       CallExpression(node) {
         if (isRequireStatement(node.callee) || isJestMock(node.callee)) {
           const literal = node.arguments[0] ?? {};


### PR DESCRIPTION
Makes the `prefer-alias-import` rule work for `import mymodule = require('../../mymodule');` style import