### PR TITLE
prefer-path-alias should support exports

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7,13 +7,13 @@ const no_mobx_1 = __importDefault(require("./rules/no-mobx"));
 const no_external_imports_1 = __importDefault(require("./rules/no-external-imports"));
 const no_root_store_imports_1 = __importDefault(require("./rules/no-root-store-imports"));
 const no_wildcard_imports_1 = __importDefault(require("./rules/no-wildcard-imports"));
-const prefer_alias_imports_1 = __importDefault(require("./rules/prefer-alias-imports"));
+const prefer_path_alias_1 = __importDefault(require("./rules/prefer-path-alias"));
 module.exports = {
     rules: {
         'no-mobx': no_mobx_1.default,
         'no-external-imports': no_external_imports_1.default,
         'no-root-store-imports': no_root_store_imports_1.default,
         'no-wildcard-imports': no_wildcard_imports_1.default,
-        'prefer-alias-imports': prefer_alias_imports_1.default,
+        'prefer-path-alias': prefer_path_alias_1.default,
     },
 };

--- a/dist/rules/no-wildcard-imports.js
+++ b/dist/rules/no-wildcard-imports.js
@@ -78,7 +78,7 @@ const reportLintError = (context, node, source) => {
     const importName = node.local.name; // e.g. for "import * as _", this will be "_"
     const { usages, usageRecords } = findValidUsages(program, importName);
     const hasInvalidUsages = usages === null || usages === void 0 ? void 0 : usages.some((usage) => isInvalidUsage(program, importName, usage));
-    if (usages && usages.length && !hasInvalidUsages) {
+    if ((usages === null || usages === void 0 ? void 0 : usages.length) && (usageRecords === null || usageRecords === void 0 ? void 0 : usageRecords.length) && !hasInvalidUsages) {
         context.report({
             node,
             messageId: 'noWildcardImports',

--- a/dist/utils/buildPathValidationListeners.js
+++ b/dist/utils/buildPathValidationListeners.js
@@ -1,0 +1,43 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildPathValidationListeners = void 0;
+const getIdentifierName = (node) => node.type === 'Identifier' ? node.name : undefined;
+const isRequireStatement = (expression) => expression.type === 'Identifier' && getIdentifierName(expression) === 'require';
+const isJestMock = (expression) => expression.type === 'MemberExpression' &&
+    getIdentifierName(expression.object) === 'jest' &&
+    getIdentifierName(expression.property) === 'mock';
+const buildPathValidationListeners = (pathValidator) => {
+    const validateExpression = (source) => {
+        if ((source === null || source === void 0 ? void 0 : source.type) === 'Literal') {
+            const literal = source;
+            if (typeof literal.value === 'string') {
+                pathValidator(literal);
+            }
+        }
+    };
+    return {
+        TSImportEqualsDeclaration(node) {
+            if (node.moduleReference.type == 'TSExternalModuleReference') {
+                const literal = node.moduleReference.expression;
+                validateExpression(literal);
+            }
+        },
+        CallExpression(node) {
+            var _a;
+            if (isRequireStatement(node.callee) || isJestMock(node.callee)) {
+                const literal = ((_a = node.arguments[0]) !== null && _a !== void 0 ? _a : null);
+                validateExpression(literal);
+            }
+        },
+        ImportDeclaration(node) {
+            validateExpression(node.source);
+        },
+        ExportAllDeclaration(node) {
+            validateExpression(node.source);
+        },
+        ExportNamedDeclaration(node) {
+            validateExpression(node.source);
+        },
+    };
+};
+exports.buildPathValidationListeners = buildPathValidationListeners;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3782,9 +3782,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "@types/estree": "0.0.51",
     "@types/jest": "^27.0.2",
     "@types/node": "^14.14.20",
-    "@typescript-eslint/eslint-plugin": "^4.28.5",
-    "@typescript-eslint/experimental-utils": "^4.28.5",
+    "@typescript-eslint/eslint-plugin": "^4.33.0",
+    "@typescript-eslint/experimental-utils": "^4.33.0",
     "@typescript-eslint/parser": "^4.28.5",
     "eslint": "^7.19.0",
     "eslint-config-prettier": "^8.5.0",
@@ -21,8 +21,8 @@
     "typescript": "^4.4.2"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "4.x",
-    "@typescript-eslint/parser": "4.x"
+    "@typescript-eslint/eslint-plugin": "4.33.x",
+    "@typescript-eslint/parser": "4.33.x"
   },
   "scripts": {
     "build": "./node_modules/typescript/bin/tsc -b",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import noMobx from './rules/no-mobx';
 import noExternalImports from './rules/no-external-imports';
 import noRootStoreImports from './rules/no-root-store-imports';
 import noWildcardImports from './rules/no-wildcard-imports';
-import preferAliasImports from './rules/prefer-alias-imports';
+import preferPathAlias from './rules/prefer-path-alias';
 
 module.exports = {
   rules: {
@@ -10,6 +10,6 @@ module.exports = {
     'no-external-imports': noExternalImports,
     'no-root-store-imports': noRootStoreImports,
     'no-wildcard-imports': noWildcardImports,
-    'prefer-alias-imports': preferAliasImports,
+    'prefer-path-alias': preferPathAlias,
   },
 };

--- a/src/rules/no-external-imports.spec.ts
+++ b/src/rules/no-external-imports.spec.ts
@@ -102,5 +102,23 @@ ruleTester.run('no-external-imports', noExternalImports, {
       code: "import something = require('../../second_module/somefile');",
       errors: [{ messageId: 'noExternalImports' }],
     },
+    {
+      // with export-all declaration
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "export * as something from '../../second_module/some_file'",
+      errors: [{ messageId: 'noExternalImports' }],
+    },
+    {
+      // with named export
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "export { something } from '../../second_module/some_file'",
+      errors: [{ messageId: 'noExternalImports' }],
+    },
+    {
+      // with export assignment
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "export = require('../../second_module/some_file')",
+      errors: [{ messageId: 'noExternalImports' }],
+    },
   ],
 });

--- a/src/rules/no-wildcard-imports.ts
+++ b/src/rules/no-wildcard-imports.ts
@@ -109,7 +109,7 @@ const reportLintError = (
   const importName = node.local.name; // e.g. for "import * as _", this will be "_"
   const { usages, usageRecords } = findValidUsages(program, importName);
   const hasInvalidUsages = usages?.some((usage) => isInvalidUsage(program, importName, usage));
-  if (usages && usages.length && !hasInvalidUsages) {
+  if (usages?.length && usageRecords?.length && !hasInvalidUsages) {
     context.report({
       node,
       messageId: 'noWildcardImports',

--- a/src/rules/prefer-alias-imports.spec.ts
+++ b/src/rules/prefer-alias-imports.spec.ts
@@ -1,0 +1,56 @@
+import * as tsconfigPaths from 'tsconfig-paths';
+import { RuleTester } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
+import preferAliasImports from './prefer-alias-imports';
+import { ConfigLoaderResult } from 'tsconfig-paths';
+
+const ruleTester: RuleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+});
+
+const absoluteBaseUrl = '/path/to/myapp';
+
+jest.spyOn(tsconfigPaths, 'loadConfig').mockReturnValue({
+  resultType: 'success',
+  absoluteBaseUrl,
+  paths: {
+    cypress: ['./node_modules/cypress'],
+    '@module1/*': ['first_module/*'],
+    '@module2/*': ['second_module/*'],
+    '@nested/*': ['third_module/nested/*'],
+  },
+} as unknown as ConfigLoaderResult);
+
+ruleTester.run('preferAliasImports', preferAliasImports, {
+  valid: [
+    {
+      // relative imports that don't peek into other modules are fine
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "import { something } from '../internal_file';",
+    },
+    {
+      // technically it's the same module, so no error is thrown
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "import { something } from '../../first_module/internal_file';",
+    },
+  ],
+  invalid: [
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "import { something } from '../../second_module/some_file';",
+      errors: [{ messageId: 'preferAliasImports' }],
+      output: `import { something } from '@module2/some_file';`,
+    },
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "require('../../second_module/some_file');",
+      errors: [{ messageId: 'preferAliasImports' }],
+      output: `require('@module2/some_file');`,
+    },
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "jest.mock('../../second_module/some_file');",
+      errors: [{ messageId: 'preferAliasImports' }],
+      output: `jest.mock('@module2/some_file');`,
+    },
+  ],
+});

--- a/src/rules/prefer-path-alias.spec.ts
+++ b/src/rules/prefer-path-alias.spec.ts
@@ -1,6 +1,6 @@
 import * as tsconfigPaths from 'tsconfig-paths';
 import { RuleTester } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
-import preferAliasImports from './prefer-alias-imports';
+import preferPathAlias from './prefer-path-alias';
 import { ConfigLoaderResult } from 'tsconfig-paths';
 
 const ruleTester: RuleTester = new RuleTester({
@@ -20,7 +20,7 @@ jest.spyOn(tsconfigPaths, 'loadConfig').mockReturnValue({
   },
 } as unknown as ConfigLoaderResult);
 
-ruleTester.run('preferAliasImports', preferAliasImports, {
+ruleTester.run('preferPathAlias', preferPathAlias, {
   valid: [
     {
       // relative imports that don't peek into other modules are fine
@@ -37,19 +37,19 @@ ruleTester.run('preferAliasImports', preferAliasImports, {
     {
       filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
       code: "import { something } from '../../second_module/some_file';",
-      errors: [{ messageId: 'preferAliasImports' }],
+      errors: [{ messageId: 'preferPathAlias' }],
       output: `import { something } from '@module2/some_file';`,
     },
     {
       filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
       code: "require('../../second_module/some_file');",
-      errors: [{ messageId: 'preferAliasImports' }],
+      errors: [{ messageId: 'preferPathAlias' }],
       output: `require('@module2/some_file');`,
     },
     {
       filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
       code: "jest.mock('../../second_module/some_file');",
-      errors: [{ messageId: 'preferAliasImports' }],
+      errors: [{ messageId: 'preferPathAlias' }],
       output: `jest.mock('@module2/some_file');`,
     },
   ],

--- a/src/rules/prefer-path-alias.spec.ts
+++ b/src/rules/prefer-path-alias.spec.ts
@@ -22,35 +22,85 @@ jest.spyOn(tsconfigPaths, 'loadConfig').mockReturnValue({
 
 ruleTester.run('preferPathAlias', preferPathAlias, {
   valid: [
+    // relative imports that don't peek into other modules are fine
     {
-      // relative imports that don't peek into other modules are fine
       filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
       code: "import { something } from '../internal_file';",
     },
+    // technically it's the same module, so no error is thrown
     {
-      // technically it's the same module, so no error is thrown
       filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
       code: "import { something } from '../../first_module/internal_file';",
     },
+    // random call expressions are allowed
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "const test = myFunction('../../second_module/some_file.css');",
+    },
   ],
   invalid: [
+    // import-all declaration
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "import * as asdf from '../../second_module/some_file';",
+      errors: [{ messageId: 'preferPathAlias' }],
+      output: `import * as asdf from '@module2/some_file';`,
+    },
+    // import declaration
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "import '../../second_module/some_file.css'",
+      errors: [{ messageId: 'preferPathAlias' }],
+      output: "import '@module2/some_file.css'",
+    },
+    // named import
     {
       filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
       code: "import { something } from '../../second_module/some_file';",
       errors: [{ messageId: 'preferPathAlias' }],
       output: `import { something } from '@module2/some_file';`,
     },
+    // import equals declaration
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "import test = require('../../second_module/some_file');",
+      errors: [{ messageId: 'preferPathAlias' }],
+      output: `import test = require('@module2/some_file');`,
+    },
+    // require call expression
     {
       filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
       code: "require('../../second_module/some_file');",
       errors: [{ messageId: 'preferPathAlias' }],
       output: `require('@module2/some_file');`,
     },
+    // jest.mock call expression
     {
       filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
       code: "jest.mock('../../second_module/some_file');",
       errors: [{ messageId: 'preferPathAlias' }],
       output: `jest.mock('@module2/some_file');`,
+    },
+    // export-all declaration
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "export * as something from '../../second_module/some_file'",
+      errors: [{ messageId: 'preferPathAlias' }],
+      output: `export * as something from '@module2/some_file'`,
+    },
+    // named export
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "export { something } from '../../second_module/some_file'",
+      errors: [{ messageId: 'preferPathAlias' }],
+      output: "export { something } from '@module2/some_file'",
+    },
+    // export assignment
+    {
+      filename: `${absoluteBaseUrl}/first_module/myfolder/myfile.ts`,
+      code: "export = require('../../second_module/some_file')",
+      errors: [{ messageId: 'preferPathAlias' }],
+      output: "export = require('@module2/some_file')",
     },
   ],
 });

--- a/src/rules/prefer-path-alias.ts
+++ b/src/rules/prefer-path-alias.ts
@@ -14,9 +14,9 @@ import {
 } from '@typescript-eslint/types/dist/ast-spec';
 
 type Options = { limitTo?: Array<string> };
-type MessageIds = 'preferAliasImports';
+type MessageIds = 'preferPathAlias';
 
-const RULE_NAME = 'prefer-alias-imports';
+const RULE_NAME = 'prefer-path-alias';
 
 const getConfig = (cwd: string) => {
   const configLoaderResult = loadConfig(cwd);
@@ -59,7 +59,7 @@ const buildFixFunction = (
 
 const buildPathValidator =
   (
-    context: Readonly<RuleContext<'preferAliasImports', [Options]>>,
+    context: Readonly<RuleContext<'preferPathAlias', [Options]>>,
     options: Options,
     paths: Record<string, string[]>,
     absoluteBaseUrl: string,
@@ -81,7 +81,7 @@ const buildPathValidator =
     }
     context.report({
       node,
-      messageId: 'preferAliasImports',
+      messageId: 'preferPathAlias',
       data: { alias: matchingAlias },
       fix: buildFixFunction(node, paths, matchingAlias, relativeImportPath),
     });
@@ -122,7 +122,7 @@ export default createRule<[Options], MessageIds>({
       },
     ],
     messages: {
-      preferAliasImports: 'Path alias is preferred: `{{ alias }}`',
+      preferPathAlias: 'Path alias is preferred: `{{ alias }}`',
     },
   },
   defaultOptions: [{}],

--- a/src/utils/buildPathValidationListeners.ts
+++ b/src/utils/buildPathValidationListeners.ts
@@ -1,0 +1,55 @@
+import type { RuleListener } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
+import type {
+  Expression,
+  Identifier,
+  LeftHandSideExpression,
+  Literal,
+  StringLiteral,
+} from '@typescript-eslint/types/dist/ast-spec';
+
+const getIdentifierName = (node: any) =>
+  node.type === 'Identifier' ? (node as Identifier).name : undefined;
+
+const isRequireStatement = (expression: LeftHandSideExpression) =>
+  expression.type === 'Identifier' && getIdentifierName(expression) === 'require';
+
+const isJestMock = (expression: LeftHandSideExpression) =>
+  expression.type === 'MemberExpression' &&
+  getIdentifierName(expression.object) === 'jest' &&
+  getIdentifierName(expression.property) === 'mock';
+
+export const buildPathValidationListeners = (
+  pathValidator: (node: StringLiteral) => void,
+): RuleListener => {
+  const validateExpression = (source: Expression | null) => {
+    if (source?.type === 'Literal') {
+      const literal = source as Literal;
+      if (typeof literal.value === 'string') {
+        pathValidator(literal as StringLiteral);
+      }
+    }
+  };
+  return {
+    TSImportEqualsDeclaration(node) {
+      if (node.moduleReference.type == 'TSExternalModuleReference') {
+        const literal = node.moduleReference.expression;
+        validateExpression(literal);
+      }
+    },
+    CallExpression(node) {
+      if (isRequireStatement(node.callee) || isJestMock(node.callee)) {
+        const literal = (node.arguments[0] ?? null) as Expression | null;
+        validateExpression(literal);
+      }
+    },
+    ImportDeclaration(node) {
+      validateExpression(node.source);
+    },
+    ExportAllDeclaration(node) {
+      validateExpression(node.source);
+    },
+    ExportNamedDeclaration(node) {
+      validateExpression(node.source);
+    },
+  };
+};

--- a/src/utils/createRule.ts
+++ b/src/utils/createRule.ts
@@ -8,7 +8,7 @@ export const createRule = ESLintUtils.RuleCreator((ruleName) => ruleName);
 
 interface ReportNodeDescriptor {
   readonly node: TSESTree.Node | TSESTree.Token;
-  readonly loc?: Readonly<TSESTree.SourceLocation> | Readonly<TSESTree.LineAndColumnData>;
+  readonly loc?: Readonly<TSESTree.SourceLocation>;
   message: string;
   fix?: ReportFixFunction;
 }


### PR DESCRIPTION
I noticed that certain exports were not validating this rule, such as `export { something } from '../../second_module/some_file'`. This PR renames the rule from `prefer-alias-imports` to `prefer-path-alias` and adds support for export declarations